### PR TITLE
Fix number of arguments for pay handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ crypto = AioCryptoPay(token='1337:JHigdsaASq', network=Networks.MAIN_NET)
 
 
 @crypto.pay_handler()
-async def invoice_paid(update: Update) -> None:
+async def invoice_paid(update: Update, app) -> None:
     print(update)
 
 async def create_invoice(app) -> None:


### PR DESCRIPTION
Here we're passing an `app` as an argument, but it's not handled in the example.

https://github.com/layerqa/aiocryptopay/blob/main/aiocryptopay/api.py#L298